### PR TITLE
Revert "Fix Chrome extension CORS error: Add flask-cors support with …

### DIFF
--- a/chrome-extension/README.md
+++ b/chrome-extension/README.md
@@ -47,7 +47,6 @@ A Chrome extension for easily downloading documents from CTUMP DocImage as PDF f
 1. **Click the Extension Icon** in Chrome toolbar
 2. **Configure API Server** (first time only):
    - Enter API URL (default: `http://localhost:5000`)
-   - For cloud deployments (Replit, Heroku, etc.), use your HTTPS URL (e.g., `https://your-app.replit.dev`)
    - Click "Test Connection" to verify
 
 3. **Add a Document**:
@@ -156,8 +155,6 @@ chrome-extension/
 - Verify API server is running: `python ctsample.py`
 - Check API URL in extension settings
 - Ensure no firewall blocking localhost:5000
-- **Note**: The server now includes CORS support for Chrome extensions (added in v1.3)
-- **For cloud deployments**: HTTPS origins (Replit, Heroku, etc.) are now supported
 
 #### Token Not Detected
 - Verify viewer URL is correct

--- a/ctsample.py
+++ b/ctsample.py
@@ -42,11 +42,10 @@ def _ensure(pkgs: List[str]) -> None:
             subprocess.check_call([sys.executable, "-m", "pip", "install", p])
 
 # Install third-party deps if missing
-_ensure(["httpx[http2]>=0.26", "img2pdf>=0.6.0", "pikepdf>=9.0", "flask>=2.0.0", "flask-cors>=3.0.0"])
+_ensure(["httpx[http2]>=0.26", "img2pdf>=0.6.0", "pikepdf>=9.0", "flask>=2.0.0"])
 
 # ------------------------- Web Framework (Flask) -------------------------
 from flask import Flask, render_template_string, request, jsonify, send_file, redirect, url_for
-from flask_cors import CORS
 
 import httpx
 import img2pdf
@@ -66,16 +65,6 @@ RETRIABLE_STATUSES = {429, 500, 502, 503, 504}
 # ----------------------------- Web App State ----------------------------
 app = Flask(__name__)
 app.secret_key = os.urandom(24)
-
-# Enable CORS for Chrome extension support
-# Allow requests from chrome-extension:// origins, localhost, and HTTPS (for cloud deployments)
-CORS(app, resources={
-    r"/api/*": {
-        "origins": ["chrome-extension://*", "http://localhost:*", "http://127.0.0.1:*", "https://*"],
-        "methods": ["GET", "POST", "DELETE", "OPTIONS"],
-        "allow_headers": ["Content-Type"]
-    }
-})
 
 # Global state for the web app
 app_state = {


### PR DESCRIPTION
…cloud deployment compatibility"

## Summary by Sourcery

Revert the previous addition of CORS support for the Chrome extension by removing flask-cors setup and related documentation.

Documentation:
- Remove CORS-related instructions and cloud deployment notes from the Chrome extension README

Chores:
- Remove flask-cors configuration from the Flask app
- Revert CORS setup code in ctsample.py